### PR TITLE
Use internal _charm-release jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,54 @@
 name: Release Charm to Edge and Publish Libraries
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
   push:
     branches:
       - main
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+
 jobs:
-  release:
-    uses: canonical/observability/.github/workflows/charm-release.yaml@main
+  quality-checks:
+    name: Quality Checks
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@main
     secrets: inherit
     with:
       provider: lxd
+      charmcraft-channel: 3.x/stable
+  release-charm:
+    name: Release Charm and Libraries
+    needs:
+      - quality-checks
+    uses: canonical/observability/.github/workflows/_charm-release.yaml@main
+    secrets: inherit
+  release-libs:
+    name: Release any bumped charm library
+    needs:
+      - quality-checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: charm
+
+      - name: Release libraries
+        run: |
+          # Install Charmcraft
+          sudo snap install charmcraft --classic --channel 3.x/stable
+          cd $GITHUB_WORKSPACE/charm/
+          # Get the charm name
+          charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
+          if [[ $charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
+          # For each library belonging to the charm, publish it
+          if [ -d lib/charms/$charm_name ]; then
+            for lib in $(find lib/charms/$charm_name -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+              charmcraft publish-lib $lib
+            done
+          fi
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"


### PR DESCRIPTION
Public facing workflow requires a TOKEN we don't need, use internal jobs instead.

## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charm, ... -->
