### PR TITLE
Provide current cwd as charm path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
     with:
       provider: lxd
       charmcraft-channel: 3.x/stable
+      charm-path: .
   release-charm:
     name: Release Charm and Libraries
     needs:


### PR DESCRIPTION
QA workflow does not define `.` as default value for charm paths like other workflows.

## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charm, ... -->
