### PR TITLE
Use hostname with fqdn for node_name

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -4,9 +4,9 @@
 
 """Config builder for Consul."""
 
-import socket
-
 from pydantic import BaseModel, Field
+
+from utils import get_hostname
 
 
 class Ports(BaseModel):
@@ -50,7 +50,7 @@ class ConsulConfigBuilder:
         return {
             "bind_addr": self.bind_address,
             "datacenter": self.datacenter,
-            "node_name": socket.gethostname(),
+            "node_name": get_hostname(),
             "ports": {
                 "dns": self.ports.dns,
                 "http": self.ports.http,

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utility helper functions."""
+
+import socket
+
+
+def get_hostname() -> str:
+    """Return hostname of th fqdn."""
+    hostname = socket.gethostname()
+    if "." in hostname:
+        return hostname
+
+    addrinfo = socket.getaddrinfo(
+        hostname, None, family=socket.AF_UNSPEC, flags=socket.AI_CANONNAME
+    )
+    for addr in addrinfo:
+        fqdn = addr[3]
+        if fqdn and fqdn != "localhost":
+            return fqdn
+
+    return hostname


### PR DESCRIPTION
Add logic to extract hostname with fqdn
to update node_name configuration in
consul agent conf.

## Issue
Currently the consul clients have node_name value as hostname without fqdn.
It will be better to have fqdn.

## Solution
Try to get hostname with fqdn from socket library.


## Context
Sunbeam requires consul members have same name as openstack compute node register with.