### PR TITLE
Set 24.04 as default charm base

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,1 +1,1 @@
-charmcraft-22.04.yaml
+charmcraft-24.04.yaml

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -27,8 +27,8 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy the charm and wait for active/idle status
     await ops_test.model.deploy(
-        PRINCIPAL_CHARM, application_name=PRINCIPAL_CHARM, base="ubuntu@22.04"
+        PRINCIPAL_CHARM, application_name=PRINCIPAL_CHARM, base="ubuntu@24.04"
     )
-    await ops_test.model.deploy(charm, application_name=APP_NAME, base="ubuntu@22.04", num_units=0)
+    await ops_test.model.deploy(charm, application_name=APP_NAME, base="ubuntu@24.04", num_units=0)
     await ops_test.model.integrate(APP_NAME, PRINCIPAL_CHARM)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=1000)

--- a/tox.ini
+++ b/tox.ini
@@ -96,9 +96,9 @@ depends =
 [coverage:run]
 relative_files = True
 
-[testenv:pack-24.04]
-description = Link charmcraft-24.04.yaml to charmcraft.yaml, pack and restore
+[testenv:pack-22.04]
+description = Link charmcraft-22.04.yaml to charmcraft.yaml, pack and restore
 allowlist_externals =
     sh
 commands =
-    sh -c "ln -srf {toxinidir}/charmcraft-24.04.yaml {toxinidir}/charmcraft.yaml && charmcraft pack --project-dir={toxinidir}; ln -srf {toxinidir}/charmcraft-22.04.yaml {toxinidir}/charmcraft.yaml"
+    sh -c "ln -srf {toxinidir}/charmcraft-22.04.yaml {toxinidir}/charmcraft.yaml && charmcraft pack --project-dir={toxinidir}; ln -srf {toxinidir}/charmcraft-24.04.yaml {toxinidir}/charmcraft.yaml"


### PR DESCRIPTION
Sunbeam is moving on to 24.04 for all components, manage consul-client as 24.04 first, while keeping 22.04 compatibility for the moment.