### PR TITLE
Feature: Add Consul TCP check with Unix socket and snap interface man…

### DIFF
--- a/charmcraft-22.04.yaml
+++ b/charmcraft-22.04.yaml
@@ -37,6 +37,10 @@ requires:
     interface: juju-info
     scope: container
 
+provides:
+  consul-notify:
+    interface: consul-notify
+
 links:
   issues:
   - https://github.com/canonical/consul-client-operator/issues

--- a/charmcraft-24.04.yaml
+++ b/charmcraft-24.04.yaml
@@ -37,6 +37,10 @@ requires:
     interface: juju-info
     scope: container
 
+provides:
+  consul-notify:
+    interface: consul-notify
+
 links:
   issues:
   - https://github.com/canonical/consul-client-operator/issues
@@ -57,4 +61,3 @@ config:
         Serf lan port number to be used.
       type: int
       default: 8301
-

--- a/lib/charms/consul_client/v0/consul_notify.py
+++ b/lib/charms/consul_client/v0/consul_notify.py
@@ -1,0 +1,295 @@
+"""ConsulNotify Provides and Requires module.
+
+This library contains Provider and Requirer classes for
+consul-notify interface.
+
+The provider side offers the service of network monitoring and notification.
+It monitors network connectivity to servers and notifies when issues are detected.
+
+The requirer side receives notifications about network failures
+and provides the socket path where it wants to receive these notifications.
+
+## Provider Example
+
+Import `ConsulNotifyProvider` in your charm, with the charm object and the
+relation name:
+    - self
+    - "consul-notify"
+
+An event is also available to respond to:
+    - socket_available
+
+A basic example showing the usage of the provider side:
+
+```python
+from charms.consul_client.v0.consul_notify import (
+    ConsulNotifyProvider
+)
+
+class MyProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        # ConsulNotify Provider
+        self.consul_notify = ConsulNotifyProvider(
+            self, "consul-notify",
+        )
+        self.framework.observe(
+            self.consul_notify.on.socket_available,
+            self._on_socket_available
+        )
+
+    def _on_socket_available(self, event):
+        '''React to the socket available event.
+
+        This event happens when a requirer charm relates to this charm
+        and provides its socket information.
+        '''
+        # Get the socket information
+        snap_name = self.consul_notify.snap_name
+        socket_path = self.consul_notify.unix_socket_filepath
+
+        if snap_name and socket_path:
+            # Configure TCP health check with the socket information
+            # This will enable monitoring and notification
+            self._configure_tcp_health_check(snap_name, socket_path)
+```
+
+## Requirer Example
+
+Import `ConsulNotifyRequirer` in your charm, with the charm object and the
+relation name:
+    - self
+    - "consul-notify"
+
+An event is also available to respond to:
+    - relation_ready
+
+A basic example showing the usage of the requirer side:
+
+```python
+from charms.consul_client.v0.consul_notify import (
+    ConsulNotifyRequirer
+)
+
+class MyRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        # ConsulNotify Requires
+        self.consul_notify = ConsulNotifyRequirer(
+            self, "consul-notify",
+        )
+
+        # Observe the relation_ready event
+        self.framework.observe(
+            self.consul_notify.on.relation_ready,
+            self._on_consul_notify_ready
+        )
+
+    def _on_consul_notify_ready(self, event):
+        '''React to the consul-notify relation being ready.
+
+        This event happens when the relation is created or joined.
+        '''
+        # Set the socket information for the provider
+        self.consul_notify.set_socket_info(
+            snap_name="my-service-snap",
+            unix_socket_filepath="/var/snap/my-service-snap/common/socket.sock"
+        )
+```
+"""
+
+import logging
+
+from ops.charm import CharmBase, RelationBrokenEvent, RelationChangedEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents
+from ops.model import Relation
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "1edb80abcec14c1e86a55f7e3809030a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+DEFAULT_RELATION_NAME = "consul-notify"
+
+logger = logging.getLogger(__name__)
+
+
+class SocketInfoData(BaseModel):
+    """Socket information from the requirer."""
+
+    snap_name: str = Field("The name of the snap that provides the socket")
+    unix_socket_filepath: str = Field("The UNIX socket file path")
+
+
+class SocketAvailableEvent(RelationEvent):
+    """Socket information available event."""
+
+    pass
+
+
+class SocketGoneEvent(RelationEvent):
+    """Socket information gone event."""
+
+    pass
+
+
+class ConsulNotifyProviderEvents(ObjectEvents):
+    """Consul Notify provider events."""
+
+    socket_available = EventSource(SocketAvailableEvent)
+    socket_gone = EventSource(SocketGoneEvent)
+
+
+class ConsulNotifyProvider(Object):
+    """Class to be instantiated on the provider side of the relation."""
+
+    on = ConsulNotifyProviderEvents()  # pyright: ignore
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+        events = self.charm.on[relation_name]
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_relation_broken)
+
+    def _on_relation_changed(self, event: RelationChangedEvent):
+        """Handle relation changed event."""
+        if self._validate_databag_from_relation():
+            self.on.socket_available.emit(event.relation)
+
+    def _on_relation_broken(self, event: RelationBrokenEvent):
+        """Handle relation broken event."""
+        self.on.socket_gone.emit(event.relation)
+
+    def _validate_databag_from_relation(self) -> bool:
+        try:
+            if self._consul_notify_rel:
+                databag = self._consul_notify_rel.data[self._consul_notify_rel.app]
+                SocketInfoData(**databag)  # type: ignore
+        except ValidationError as e:
+            logger.info(f"Incorrect app databag: {str(e)}")
+            return False
+
+        return True
+
+    def _get_app_databag_from_relation(self) -> dict:
+        try:
+            if self._consul_notify_rel:
+                databag = self._consul_notify_rel.data[self._consul_notify_rel.app]
+                data = SocketInfoData(**databag)  # type: ignore
+                return data.model_dump()
+        except ValidationError as e:
+            logger.info(f"Incorrect app databag: {str(e)}")
+
+        return {}
+
+    @property
+    def _consul_notify_rel(self) -> Relation | None:
+        """The Consul Notify relation."""
+        return self.framework.model.get_relation(self.relation_name)
+
+    @property
+    def snap_name(self) -> str | None:
+        """Return snap_name from requirer app data.
+
+        Returns:
+            The name of the snap that provides the socket, or None if not available
+        """
+        data = self._get_app_databag_from_relation()
+        return data.get("snap_name")
+
+    @property
+    def unix_socket_filepath(self) -> str | None:
+        """Return UNIX socket filepath from requirer app data.
+
+        Returns:
+            The path to the UNIX socket file, or None if not available
+        """
+        data = self._get_app_databag_from_relation()
+        return data.get("unix_socket_filepath")
+
+    @property
+    def is_ready(self) -> bool:
+        """Check if the relation is ready with all required data.
+
+        Returns:
+            True if both snap_name and unix_socket_filepath are available, False otherwise
+        """
+        return bool(self.snap_name and self.unix_socket_filepath)
+
+
+class RelationReadyEvent(RelationEvent):
+    """Relation ready event for the requirer side."""
+    pass
+
+
+class ConsulNotifyRequirerEvents(ObjectEvents):
+    """Consul Notify requirer events."""
+
+    relation_ready = EventSource(RelationReadyEvent)
+
+
+class ConsulNotifyRequirer(Object):
+    """Class to be instantiated on the requirer side of the relation."""
+
+    on = ConsulNotifyRequirerEvents()  # pyright: ignore
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+        events = self.charm.on[relation_name]
+        self.framework.observe(events.relation_created, self._on_relation_created)
+        self.framework.observe(events.relation_joined, self._on_relation_joined)
+
+    def _on_relation_created(self, event: RelationEvent):
+        """Handle relation created event."""
+        self.on.relation_ready.emit(event.relation)
+
+    def _on_relation_joined(self, event: RelationEvent):
+        """Handle relation joined event."""
+        self.on.relation_ready.emit(event.relation)
+
+    def set_socket_info(
+        self,
+        snap_name: str,
+        unix_socket_filepath: str,
+    ) -> None:
+        """Set socket information on the relation.
+
+        Args:
+            snap_name: The name of the snap that provides the socket
+            unix_socket_filepath: The path to the UNIX socket file
+        """
+        if not self.charm.unit.is_leader():
+            logging.debug("Not a leader unit, skipping set socket info")
+            return
+
+        try:
+            databag = SocketInfoData(
+                snap_name=snap_name,
+                unix_socket_filepath=unix_socket_filepath,
+            )
+        except ValidationError as e:
+            logger.info(f"Requirer trying to set incorrect app data {str(e)}")
+            return
+
+        _snap_name: str = databag.snap_name
+        _unix_socket_filepath: str = databag.unix_socket_filepath
+
+        for relation in self.framework.model.relations.get(self.relation_name, []):
+            if relation and relation.app:
+                logging.debug(
+                    f"Setting socket info on relation {relation.app.name} {relation.name}/{relation.id}"
+                )
+                relation.data[self.charm.app]["snap_name"] = _snap_name
+                relation.data[self.charm.app]["unix_socket_filepath"] = _unix_socket_filepath

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -4,9 +4,15 @@
 
 """Config builder for Consul."""
 
+import logging
+import shutil
+from pathlib import Path
+
 from pydantic import BaseModel, Field
 
 from utils import get_hostname
+
+logger = logging.getLogger(__name__)
 
 
 class Ports(BaseModel):
@@ -33,13 +39,19 @@ class ConsulConfigBuilder:
         self,
         bind_address: str | None,
         datacenter: str,
+        tcp_check: bool,
+        snap_name: str,
         consul_servers: list[str],
         ports: Ports,
+        unix_socket_filepath: str | None = None,
     ):
         self.bind_address = bind_address or "0.0.0.0"
         self.datacenter = datacenter
+        self.tcp_check = tcp_check
+        self.snap_name = snap_name
         self.consul_servers = consul_servers
         self.ports = ports
+        self.unix_socket_filepath = unix_socket_filepath
 
     def build(self) -> dict:
         """Build consul client config file.
@@ -47,7 +59,7 @@ class ConsulConfigBuilder:
         Service mesh, UI, DNS, gRPC, Serf WAN are not supported
         and disabled.
         """
-        return {
+        config = {
             "bind_addr": self.bind_address,
             "datacenter": self.datacenter,
             "node_name": get_hostname(),
@@ -63,3 +75,42 @@ class ConsulConfigBuilder:
             },
             "retry_join": self.consul_servers,
         }
+
+        if self.tcp_check and self.unix_socket_filepath:
+            self._write_tcp_check_script()
+            config["enable_script_checks"] = True
+
+            args = ["python3", str(self.consul_tcp_check), *self.consul_servers]
+            args.extend(["--socket-path", self.unix_socket_filepath])
+
+            config["services"] = [
+                {
+                    "name": "tcp-health-check",
+                    "check": {
+                        "id": "tcp-check",
+                        "name": "TCP Health Check",
+                        "args": args,
+                        "interval": "10s",
+                        "timeout": "5s",
+                    },
+                }
+            ]
+        return config
+
+    def _write_tcp_check_script(self):
+        """Copy the TCP health check Python script to the data directory."""
+        tcp_check_script_path = Path(__file__).parent / "tcp_health_check.py"
+        destination_path = self.consul_tcp_check
+
+        if not destination_path.exists():
+            try:
+                shutil.copy(tcp_check_script_path, destination_path)
+                logger.info(f"TCP health check script copied to {destination_path}")
+            except Exception as e:
+                logger.error(f"Failed to copy TCP health check script: {e}")
+                raise
+
+    @property
+    def consul_tcp_check(self) -> Path:
+        """Return the Consul TCP check script path."""
+        return Path(f"/var/snap/{self.snap_name}/common/consul/data/tcp_health_check.py")

--- a/src/tcp_health_check.py
+++ b/src/tcp_health_check.py
@@ -1,0 +1,98 @@
+"""Health check functions for monitoring TCP servers and sending alert when required."""
+
+import argparse
+import enum
+import json
+import logging
+import os
+import socket
+import sys
+import time
+
+PROTOCOL_VERSION = "1.0"
+
+
+class NetworkStatus(enum.Enum):
+    """Enum for network interface status."""
+
+    NIC_DOWN = "nic-down"
+
+
+def send_nic_down_alert(socket_path):
+    """Send nic down signal through Unix socket.
+
+    Args:
+        socket_path: Path to the Unix socket.
+    """
+    socket_path = os.path.join(os.environ["SNAP_DATA"], socket_path)
+    logging.info(f"Sending nic down alert signal via Unix socket at {socket_path}...")
+    try:
+        message = {
+            "version": PROTOCOL_VERSION,
+            "timestamp": time.time(),
+            "status": NetworkStatus.NIC_DOWN.value,
+        }
+
+        json_message = json.dumps(message)
+        logging.debug(f"Sending message: {json_message}")
+
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect(socket_path)
+            sock.sendall(json_message.encode())
+
+            response = sock.recv(1024).decode().strip()
+            logging.info(f"Response: {response}")
+
+            response_data = json.loads(response)
+            if response_data.get("status") == "error":
+                logging.error(f"Error from server: {response_data.get('message')}")
+
+    except socket.error as e:
+        logging.error(f"Socket error: {e}")
+    except Exception as e:
+        logging.error(f"Error sending alert signal: {e}")
+
+
+def tcp_check(servers, socket_path):
+    """Perform a TCP health check on a list of servers.
+
+    Args:
+        servers: List of servers to check in format "host:port"
+        socket_path: Path to the Unix socket.
+    """
+    nic_down = False
+
+    for server in servers:
+        host, port = server.split(":")
+        port = int(port)
+
+        try:
+            with socket.create_connection((host, port), timeout=5):
+                logging.info(f"TCP check successful for {server}")
+        except (socket.timeout, socket.error) as e:
+            logging.warning(f"TCP check failed for {server}: {e}")
+            nic_down = True
+
+    if nic_down:
+        if socket_path:
+            send_nic_down_alert(socket_path)
+        else:
+            logging.error("Cannot send alert: socket_path is required but was not provided")
+    else:
+        logging.info("✅ All servers reachable. No alert triggered.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="TCP health check for Consul servers")
+    parser.add_argument("servers", nargs="+", help="List of servers to check in format host:port")
+    parser.add_argument("--socket-path", "-s", help="Path to the Unix socket")
+
+    args = parser.parse_args()
+
+    if not args.servers:
+        logging.error(
+            "Usage: python3 tcp_health_check.py <IP:PORT> [<IP:PORT>...] [--socket-path PATH]"
+        )
+        sys.exit(1)
+
+    tcp_check(args.servers, args.socket_path)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -39,6 +39,18 @@ def write_config():
         yield p
 
 
+@pytest.fixture()
+def connect_snap_interface():
+    with patch.object(ConsulCharm, "_connect_snap_interface") as p:
+        yield p
+
+
+@pytest.fixture()
+def write_tcp_check_script():
+    with patch("config_builder.ConsulConfigBuilder._write_tcp_check_script") as p:
+        yield p
+
+
 def test_start(harness: Harness[ConsulCharm], snap):
     harness.begin_with_initial_hooks()
     assert harness.model.unit.status == BlockedStatus("Integration consul-cluster missing")
@@ -101,3 +113,199 @@ def test_consul_config_changed(harness: Harness[ConsulCharm], snap, read_config,
     config = write_config.mock_calls[0].args[1]
     config = json.loads(config)
     assert config.get("ports", {}).get("serf_lan") == serf_lan_port
+
+
+def test_consul_notify_socket_available(
+    harness: Harness[ConsulCharm],
+    snap,
+    read_config,
+    write_config,
+    connect_snap_interface,
+    write_tcp_check_script,
+):
+    """Test consul-notify relation socket available event."""
+    datacenter = "test-dc"
+    join_server_addresses = ["10.20.0.10:8301"]
+    snap_name = "test-snap"
+    socket_path = "data/socket.sock"
+
+    read_config.return_value = {
+        "bind_addr": "10.10.0.10",
+        "datacenter": datacenter,
+        "ports": {
+            "dns": -1,
+            "http": -1,
+            "https": -1,
+            "grpc": -1,
+            "grpc_tls": -1,
+            "serf_lan": 8301,
+            "serf_wan": -1,
+            "server": 8300,
+        },
+        "retry_join": [join_server_addresses],
+    }
+
+    harness.add_relation(
+        "consul-cluster",
+        "consul-server",
+        app_data={
+            "datacenter": datacenter,
+            "internal_gossip_endpoints": json.dumps(None),
+            "external_gossip_endpoints": json.dumps(join_server_addresses),
+            "internal_http_endpoint": json.dumps(None),
+            "external_http_endpoint": json.dumps(None),
+        },
+    )
+
+    _ = harness.add_relation(
+        "consul-notify",
+        "test-app",
+        app_data={
+            "snap_name": snap_name,
+            "unix_socket_filepath": socket_path,
+        },
+    )
+
+    harness.begin_with_initial_hooks()
+
+    assert harness.model.unit.status == ActiveStatus()
+
+    charm = harness.charm
+    assert charm.notify_snap_name == snap_name
+    assert charm.unix_socket_filepath == socket_path
+
+    connect_snap_interface.assert_called_with(charm.snap_name, snap_name, "consul-socket")
+    assert connect_snap_interface.call_count >= 1
+
+    assert write_config.called
+    config = write_config.call_args[0][1]
+    config_dict = json.loads(config)
+    assert config_dict.get("enable_script_checks") is True
+    assert "services" in config_dict
+
+    services = config_dict["services"]
+    assert len(services) == 1
+    tcp_check_service = services[0]
+    assert tcp_check_service["name"] == "tcp-health-check"
+    assert tcp_check_service["check"]["id"] == "tcp-check"
+    assert tcp_check_service["check"]["name"] == "TCP Health Check"
+    assert "--socket-path" in tcp_check_service["check"]["args"]
+    assert socket_path in tcp_check_service["check"]["args"]
+
+
+def test_consul_notify_socket_gone(
+    harness: Harness[ConsulCharm], snap, read_config, write_config, write_tcp_check_script
+):
+    """Test consul-notify relation socket gone event."""
+    datacenter = "test-dc"
+    join_server_addresses = ["10.20.0.10:8301"]
+    snap_name = "test-snap"
+    socket_path = "data/socket.sock"
+
+    read_config.return_value = {
+        "bind_addr": "10.10.0.10",
+        "datacenter": datacenter,
+        "ports": {
+            "dns": -1,
+            "http": -1,
+            "https": -1,
+            "grpc": -1,
+            "grpc_tls": -1,
+            "serf_lan": 8301,
+            "serf_wan": -1,
+            "server": 8300,
+        },
+        "retry_join": [join_server_addresses],
+    }
+
+    harness.add_relation(
+        "consul-cluster",
+        "consul-server",
+        app_data={
+            "datacenter": datacenter,
+            "internal_gossip_endpoints": json.dumps(None),
+            "external_gossip_endpoints": json.dumps(join_server_addresses),
+            "internal_http_endpoint": json.dumps(None),
+            "external_http_endpoint": json.dumps(None),
+        },
+    )
+
+    relation_id = harness.add_relation(
+        "consul-notify",
+        "test-app",
+        app_data={
+            "snap_name": snap_name,
+            "unix_socket_filepath": socket_path,
+        },
+    )
+
+    harness.begin_with_initial_hooks()
+
+    charm = harness.charm
+    assert charm.notify_snap_name == snap_name
+    assert charm.unix_socket_filepath == socket_path
+
+    harness.remove_relation(relation_id)
+
+    assert charm.unix_socket_filepath is None
+
+    config = write_config.call_args[0][1]
+    config_dict = json.loads(config)
+    assert config_dict.get("enable_script_checks") is not True
+    assert "services" not in config_dict or len(config_dict.get("services", [])) == 0
+
+
+def test_consul_notify_relation_properties(
+    harness: Harness[ConsulCharm], snap, read_config, write_config, write_tcp_check_script
+):
+    """Test consul-notify relation properties and is_ready functionality."""
+    datacenter = "test-dc"
+    join_server_addresses = ["10.20.0.10:8301"]
+    snap_name = "test-snap"
+    socket_path = "data/socket.sock"
+
+    read_config.return_value = {
+        "bind_addr": "10.10.0.10",
+        "datacenter": datacenter,
+        "ports": {
+            "dns": -1,
+            "http": -1,
+            "https": -1,
+            "grpc": -1,
+            "grpc_tls": -1,
+            "serf_lan": 8301,
+            "serf_wan": -1,
+            "server": 8300,
+        },
+        "retry_join": [join_server_addresses],
+    }
+
+    harness.add_relation(
+        "consul-cluster",
+        "consul-server",
+        app_data={
+            "datacenter": datacenter,
+            "internal_gossip_endpoints": json.dumps(None),
+            "external_gossip_endpoints": json.dumps(join_server_addresses),
+            "internal_http_endpoint": json.dumps(None),
+            "external_http_endpoint": json.dumps(None),
+        },
+    )
+
+    harness.begin_with_initial_hooks()
+
+    charm = harness.charm
+    assert not charm.consul_notify.is_ready
+
+    harness.add_relation(
+        "consul-notify",
+        "test-app",
+        app_data={
+            "snap_name": snap_name,
+            "unix_socket_filepath": socket_path,
+        },
+    )
+
+    assert charm.consul_notify.is_ready
+    assert charm.consul_notify.snap_name == snap_name
+    assert charm.consul_notify.unix_socket_filepath == socket_path


### PR DESCRIPTION
## Issue

This PR introduces support for TCP health checks to monitor the accessibility of Consul servers. In high-availability scenario.

## Solution

* Added a new config option `enable-tcp-check` to the charm metadata.
* Updated `charm.py` to read and store this config value as a boolean.
* Extended `ConsulConfigBuilder` to optionally configure Consul's `enable_script_checks` and add a custom `tcp-health-check` service.
* Created a new script `tcp_health_check.py` which:
  * Attempts TCP connections to Consul server endpoints.
  * Sends a shutdown signal to the hypervisor via a Unix domain socket if any server is unreachable.

## Context

This change is part of an initiative to integrate health monitoring with instance-level high availability. The TCP check will be executed by Consul's script check mechanism and communicates over a Unix socket with the `openstack-hypervisor` snap to trigger shutdowns.

## Testing Instructions

Please note that for the following to work, we will have to have the hypervisor snap to be deployed with the corresponding relevant changes too, as the hypervisor will need to have the listener service deployed that is responsible for the pre-evacuation setup.

1. Deploy the charm with `enable-tcp-check` set to `true`.
2. Confirm that the TCP check configuration appears in `/var/snap/<snap-name>/common/consul/config/client.json`.
3. Bring the NIC down.
4. Verify that the TCP health check script executes, fails the connection, and sends a shutdown signal.
5. Monitor logs for confirmation of behavior (both Consul and hypervisor logs). The hypervisor should shutdown the underlying VMs and set the state of the host to "down" which triggers the VM evacuation.

## Upgrade Notes
--

