### PR TITLE
fix snap consul connect

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -214,7 +214,7 @@ class ConsulCharm(CharmBase):
             snap_cache = snap.SnapCache()
             snap_obj = snap_cache[plug_snap]
 
-            snap_obj.connect(interface, service=slot_snap)
+            snap_obj.connect(interface, service=slot_snap, slot=interface)
             logger.info(
                 f"Successfully connected snap interfaces: {plug_snap}:{interface} -> {slot_snap}:{interface}"
             )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -982,6 +982,20 @@ def test_connect_snap_interface_snap_not_found(harness: Harness[ConsulCharm], sn
     harness.charm._connect_snap_interface("plug-snap", "slot-snap", "test-interface")
 
 
+def test_connect_snap_interface_calls_connect_with_service_and_slot(
+    harness: Harness[ConsulCharm], snap
+):
+    """Test _connect_snap_interface calls snap connect with service and slot for full command."""
+    connect_mock = snap.SnapCache.return_value.__getitem__.return_value.connect
+
+    harness.begin()
+    harness.charm._connect_snap_interface("plug-snap", "slot-snap", "test-interface")
+
+    connect_mock.assert_called_once_with(
+        "test-interface", service="slot-snap", slot="test-interface"
+    )
+
+
 def test_disconnect_snap_interface_success(harness: Harness[ConsulCharm]):
     """Test _disconnect_snap_interface successful disconnection."""
     with patch("subprocess.run") as run_mock:


### PR DESCRIPTION
## Issue
snap consul fails to connect with openstack-hypervisor
LP https://bugs.launchpad.net/snap-openstack/+bug/2143322

## Solution
Fix the slot interface


## Testing Instructions
Tested via jhack 
jhack fire consul-client-management/0 consul-notify-relation-changed



## Upgrade Notes
<!-- To upgrade from an older revision of charm, ... -->
